### PR TITLE
we currently can't copy arrays with multidimensional dtypes; fixed

### DIFF
--- a/tests/test_lib_basics.py
+++ b/tests/test_lib_basics.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import tinygraph as tg
+from tinygraph.tinygraph import _extract_1d_dtype, _extract_2d_dtype
 import graph_test_suite
 import io
 import pytest
@@ -222,3 +223,53 @@ def test_copy_suite(test_name):
         g1 = g.copy()
         assert tg.util.graph_equality(g1, g)
         
+
+def test_vert_prop_with_multiple_dims():
+    """
+    There are some issues with per-vert properties having structured types, 
+    like copying doesn't work
+    """
+    N = 10
+    M = 5
+    g1 = tg.TinyGraph(10, vp_types = {'big' : '4float32'})
+
+    g2 = g1.copy()
+    
+                      
+
+
+
+def test_extract_low_dimension_dtypes():
+
+    x = np.zeros(10, 'float32,float32')
+    assert x.shape == (10,)
+
+    # this is the undesired behavior
+    x = np.zeros(10, '3float32')
+    assert x.shape == (10,3)
+
+    new_dt = _extract_1d_dtype(x)
+
+    assert new_dt == np.dtype('3float32')
+
+    x = np.zeros(10, dtype=('float32', (3, 2)))
+    
+    new_dt = _extract_1d_dtype(x)
+    print('the new dt is', new_dt)
+    assert new_dt == np.dtype(('float32', (3, 2)))
+
+
+    # now 2d 
+    x = np.zeros((10,15), 'float32,float32')
+    assert x.shape == (10,15)
+    
+    # this is the undesired behavior
+    x = np.zeros((10, 15), '3float32')
+    assert x.shape == (10,15, 3)
+
+    new_dt = _extract_2d_dtype(x)
+
+    assert new_dt == np.dtype(('float32', (3,)))
+
+    
+    

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -389,3 +389,14 @@ def test_merge_suite(test_name):
         # Adjacency
         assert np.array_equal(g1.adjacency, gg.adjacency[:g1.vert_N, :g1.vert_N])
         assert np.array_equal(g2.adjacency, gg.adjacency[g1.vert_N:, g1.vert_N:])
+
+
+
+def test_permute_multi_dtype():
+    """
+    Can we permute a graph with complex vert dtypes
+    """
+
+    g1 = tg.TinyGraph(5, vp_types = {'big' : '4float32'})
+    g1 = permute(g1,   [3,4,1,2,0])
+        

--- a/tinygraph/tinygraph.py
+++ b/tinygraph/tinygraph.py
@@ -398,10 +398,7 @@ class TinyGraph:
         Outputs:
             new_graph (TinyGraph): Deep copy of TinyGraph instance.
         """
-        v_p = {k : _extract_1d_dtype(v) for k, v in self.v.items()}
-        e_p = {k : _extract_2d_dtype(e) for k, e in self.e_p.items()}
-
-        new_graph = TinyGraph(self.__vert_N, self.adjacency.dtype, v_p, e_p)
+        new_graph = empty_like(self)
         new_graph.adjacency[:] = self.adjacency
 
         # Set vertex properties
@@ -605,3 +602,14 @@ def _extract_2d_dtype(x):
         dt = x.dtype
     return dt
     
+def empty_like(g):
+    """
+    Return a new empty graph like g, with same vert property types and 
+    edge property types.
+    """
+
+    v_p = {k : _extract_1d_dtype(v) for k, v in g.v.items()}
+    e_p = {k : _extract_2d_dtype(e) for k, e in g.e_p.items()}
+    
+    new_graph = TinyGraph(g.vert_N, g.adjacency.dtype, v_p, e_p)
+    return new_graph

--- a/tinygraph/tinygraph.py
+++ b/tinygraph/tinygraph.py
@@ -602,14 +602,18 @@ def _extract_2d_dtype(x):
         dt = x.dtype
     return dt
     
-def empty_like(g):
+def empty_like(g, N=None):
     """
     Return a new empty graph like g, with same vert property types and 
-    edge property types.
+    edge property types, and by default the same size.
+
+    N: number of nodes of output graph. 
     """
 
     v_p = {k : _extract_1d_dtype(v) for k, v in g.v.items()}
     e_p = {k : _extract_2d_dtype(e) for k, e in g.e_p.items()}
-    
-    new_graph = TinyGraph(g.vert_N, g.adjacency.dtype, v_p, e_p)
+
+    if N is None:
+        N = g.vert_N
+    new_graph = TinyGraph(N, g.adjacency.dtype, v_p, e_p)
     return new_graph

--- a/tinygraph/util.py
+++ b/tinygraph/util.py
@@ -60,7 +60,7 @@ def _subgraph_relabel(g, vert_iter):
         sg (TinyGraph): subgraph with vertices in the same order as vert_iter.
     """
     N = len(vert_iter)
-    new_g = tg.empty_like(g)
+    new_g = tg.empty_like(g, N)
     # Copy graph props
     # new_g.props = {k:v for k, v in g.props.items()}
     new_g.props = deepcopy(g.props)

--- a/tinygraph/util.py
+++ b/tinygraph/util.py
@@ -60,9 +60,7 @@ def _subgraph_relabel(g, vert_iter):
         sg (TinyGraph): subgraph with vertices in the same order as vert_iter.
     """
     N = len(vert_iter)
-    new_g = tg.TinyGraph(N, g.adjacency.dtype,
-                    {p:val.dtype for p, val in g.v.items()},
-                    {p:val.dtype for p, val in g.e.items()})
+    new_g = tg.empty_like(g)
     # Copy graph props
     # new_g.props = {k:v for k, v in g.props.items()}
     new_g.props = deepcopy(g.props)

--- a/tinygraph/version.py
+++ b/tinygraph/version.py
@@ -2,4 +2,4 @@
 Stand-alone module that's the single-source for version information
 """
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'


### PR DESCRIPTION
This is a little in the weeds, but right now if we have a vertex type that's a structured numpy array with homogeneous elements, we get an error; this fixes that. 